### PR TITLE
Added function to prevent endless spam when not in #bot-battle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 TOKEN.json
 log.txt
+node_modules/

--- a/Goosebot/GOOSEbot.js
+++ b/Goosebot/GOOSEbot.js
@@ -40,7 +40,7 @@ client.on('message', msg => {
 
 			/*\ This function checks if its in the #bot-battle channel. 
 			|*|	If it is not in #bot-battle and the last time it had to reply wasnt in the same channel it will reply to the users that send "honk"
-			|*| The first else if will trigger if it hasn't been said in #bot-battle, if it was in the same channel as the last one and if the user was not GOOSEbot.
+			|*| The first else if will trigger if it hasn't been said in #bot-battle, if it was in the same channel as the last one and if the user was not HONKbot.
 			|*| If those 3 conditions are true, it'll reply
 			|*|	The last else if checks again if it is in #bot-battle. If it is, it will reply without any other conditions
 			\*/

--- a/Goosebot/GOOSEbot.js
+++ b/Goosebot/GOOSEbot.js
@@ -20,6 +20,7 @@ const logger = myLoggers.getLogger("default");
 
 var sum = 0;
 var prefix = 'G:sum';
+var lastChannel;
 
 // Initialization 
 client.on("ready", () =>{
@@ -36,8 +37,25 @@ client.on('message', msg => {
 	var string = msg.content.toUpperCase();
     var count = (string.match(/HONK/g) || []).length;
 		for (i = 0; i < count; i++) {
-            msg.reply('*GOOSE*');
-		sum = sum + 1;
+
+			/*\ This function checks if its in the #bot-battle channel. 
+			|*|	If it is not in #bot-battle and the last time it had to reply wasnt in the same channel it will reply to the users that send "honk"
+			|*| The first else if will trigger if it hasn't been said in #bot-battle, if it was in the same channel as the last one and if the user was not GOOSEbot.
+			|*| If those 3 conditions are true, it'll reply
+			|*|	The last else if checks again if it is in #bot-battle. If it is, it will reply without any other conditions
+			\*/
+			console.log(lastChannel)
+
+			if(msg.channel !== "708022728560738344" && lastChannel !== msg.channel.id) {
+				lastChannel = msg.channel.id;
+				msg.reply('*GOOSE*')
+			}else if(msg.channel !== "708022728560738344" && lastChannel == msg.channel.id && msg.author.id !== "707372782211694684"){
+				lastChannel = msg.channel.id;
+				msg.reply('*GOOSE*')
+			} else if(msg.channel == "708022728560738344"){
+				msg.reply('*GOOSE*');
+				sum = sum + 1;
+			}
         }
 });
 

--- a/Honkbot/HONKbot.js
+++ b/Honkbot/HONKbot.js
@@ -20,6 +20,7 @@ var created = moment().format('YYYY-MM-DD hh:mm:ss');
 	
 var sum = 0;
 var prefix = 'H:sum';
+var lastChannel;
 
 // Initialization 
 client.on("ready", () =>{
@@ -35,10 +36,29 @@ client.on("ready", () =>{
 client.on('message', msg => {
 	var string = msg.content.toUpperCase();
     var count = (string.match(/GOOSE/g) || []).length;
-		for (i = 0; i < count; i++) {
-            msg.reply('*HONK*');
-		sum = sum + 1;
-        }
+	for (i = 0; i < count; i++) {
+
+		/*\ This function checks if its in the #bot-battle channel. 
+		|*|	If it is not in #bot-battle and the last time it had to reply wasnt in the same channel it will reply to the users that send "honk"
+		|*| The first else if will trigger if it hasn't been said in #bot-battle, if it was in the same channel as the last one and if the user was not GOOSEbot.
+		|*| If those 3 conditions are true, it'll reply
+		|*|	The last else if checks again if it is in #bot-battle. If it is, it will reply without any other conditions
+		\*/
+					//This is the channel id of #bot-battle
+console.log(lastChannel)
+
+		if(msg.channel !== "708022728560738344" && lastChannel !== msg.channel.id) {
+			lastChannel = msg.channel.id;
+			msg.reply('*HONK*')
+		}else if(msg.channel !== "708022728560738344" && lastChannel == msg.channel.id && msg.author.id !== "707305819443560468"){
+console.log("author" + msg.author.id)
+			lastChannel = msg.channel.id;
+			msg.reply('*HONK*')
+		} else if(msg.channel == "708022728560738344"){
+			msg.reply('*HONK*');
+			sum = sum + 1;
+		} 
+	}
 });
 
 // G:sum command, which makes the bot respond with the current sum


### PR DESCRIPTION
When Honk or Goose is mentioned in other channels the bots will keep spamming.
I added a new check in the main client.on function to check whether or not the other bot already replied.

If it is not in #bot-battle and the last time it had to reply wasn't in the same channel it will reply to the users that send "honk"
The first else if will trigger if it hasn't been said in #bot-battle, if it was in the same channel as the last one and if the user was not the other bot.
If those 3 conditions are true, it'll reply
The last else if checks again if it is in #bot-battle. If it is, it will reply without any other condition